### PR TITLE
Add BitLinear quantization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ RADLADS Step 1:
 RADLADS Step 2:
 `RWKV_TORCH_COMPILE=0 RWKV_JIT_ON=0 python3 train.py -c configs/qwen7b.yaml -c configs/qwerky7.yaml -c configs/qwen7binstructteacher.yaml -c configs/distill3.yaml --train.load_model out/L28-D3584-qwerky7_qwen2-2/rwkv-final.pth`
 
+RADLADS Step 3 (BitNet KD):
+`RWKV_TORCH_COMPILE=0 RWKV_JIT_ON=0 python3 train.py -c configs/qwen7b.yaml -c configs/qwerky7.yaml -c configs/qwen7binstructteacher.yaml -c configs/distill3.yaml --model.bitlinear 1 --train.train_stage 4 --train.teacher.path out/L28-D3584-qwerky7_qwen2-3/rwkv-final.pth`
+
 You can convert the resulting PTH files back to safetensors format for use with HF Transformers via
 `python3 convert_to_safetensors.py out/L28-D3584-qwerky7_qwen2-3/rwkv-final.pth RADRWKV7Qwen2.5-7B/model.safetensors`
 (note, you can list just a directory and it will emit chunked files instead of a single safetensors but sometimes HF has some issues with this and you have to convert to a single file first, and then from that to the chunks using this same convert_to_safetensors.py tool)

--- a/configs.py
+++ b/configs.py
@@ -27,6 +27,8 @@ class Model_Config:
     rms_norm_eps:float = 1e-06
     vocab_padding_idx:int|None = None
 
+    bitlinear:int = 0
+
 
 @dataclass(kw_only=True)
 class RoPE_Config:

--- a/models/qwen2.py
+++ b/models/qwen2.py
@@ -1259,12 +1259,16 @@ class Model_qwen2(nn.Module): # Qwen2CausalLM
         self.model = None
 
     def configure_model(self):
-        if self.model is not None: 
+        if self.model is not None:
             return
 
         self.model = Qwen2Decoder(self.config)
 
         self.lm_head = nn.Linear(self.config.model.n_embd, self.config.model.vocab_size, bias=False)
+
+        if getattr(self.config.model, 'bitlinear', 0):
+            from src.bitlinear import replace_linear_with_bitlinear
+            replace_linear_with_bitlinear(self)
 
     def set_grads(self):
         train_config = self.config.train

--- a/src/bitlinear.py
+++ b/src/bitlinear.py
@@ -1,0 +1,43 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+from .norm import RMSNorm
+
+
+def activation_quant(x: torch.Tensor) -> torch.Tensor:
+    """Activation quantization with Straight-Through Estimator."""
+    scale = 127.0 / x.abs().max(dim=-1, keepdim=True).values.clamp_(min=1e-5)
+    y = (x * scale).round().clamp_(-128, 127) / scale
+    return y
+
+
+def weight_quant(w: torch.Tensor) -> torch.Tensor:
+    """Ternary weight quantization with Straight-Through Estimator."""
+    scale = 1.0 / w.abs().mean().clamp_(min=1e-5)
+    u = (w * scale).round().clamp_(-1, 1) / scale
+    return u
+
+class BitLinearWithRMS(nn.Linear):
+    """Linear layer preceded by RMS norm and ternary quantization."""
+    def __init__(self, in_features, out_features, bias=True):
+        super().__init__(in_features, out_features, bias=bias)
+        self.rms = RMSNorm(in_features, weight_scaling=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply RMS norm and STE-based ternary quantization."""
+        x_norm = self.rms(x)
+        x_quant = x_norm + (activation_quant(x_norm) - x_norm).detach()
+        w_quant = self.weight + (weight_quant(self.weight) - self.weight).detach()
+        return F.linear(x_quant, w_quant, self.bias)
+
+def replace_linear_with_bitlinear(module):
+    for name, child in list(module.named_children()):
+        if isinstance(child, nn.Linear) and not isinstance(child, BitLinearWithRMS):
+            new_layer = BitLinearWithRMS(child.in_features, child.out_features, bias=(child.bias is not None))
+            with torch.no_grad():
+                new_layer.weight.copy_(child.weight)
+                if child.bias is not None:
+                    new_layer.bias.copy_(child.bias)
+            setattr(module, name, new_layer)
+        else:
+            replace_linear_with_bitlinear(child)

--- a/src/model.py
+++ b/src/model.py
@@ -183,6 +183,11 @@ class Transformer(nn.Module):
         #if self.training and hasattr(config, 'train') and config.train is not None and (getattr(config.train, 'load_partial', 0) or getattr(config.train, 'train_stage', 0) == 0):
         #    self.init_weights()
 
+    def configure_model(self):
+        if getattr(self.config.model, 'bitlinear', 0):
+            from .bitlinear import replace_linear_with_bitlinear
+            replace_linear_with_bitlinear(self)
+
     def ckpt(self, block, *block_args):
         if block.training and self.config.train.grad_cp == 1:
             if "deepspeed" in self.config.train.strategy:


### PR DESCRIPTION
## Summary
- add bitlinear option in config
- implement BitLinearWithRMS and utility to replace linear layers
- enable bitlinear conversion in Transformer and Qwen2 models
- document BitNet distillation stage
- use STE-based weight/activation quantization

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683a707acdd88323b01f3cb83d414704