### PR TITLE
Add Qwen2.5-7B Instruct teacher config

### DIFF
--- a/configs/qwen7binstructteacher.yaml
+++ b/configs/qwen7binstructteacher.yaml
@@ -1,0 +1,19 @@
+train:
+  teacher:
+    path: out/Qwen2.5-7B-Instruct.pth
+    model:
+      __type__: configs.Transformer_Config
+      #tmix: qwen2
+      classname: qwen2
+      ctx_len: 512 # 4096
+      vocab_size: 152064
+      vocab_padding_idx: 151646
+      num_key_value_heads: 4
+      head_size: 128
+      n_embd: 3584
+      dim_ffn: 18944
+      rms_norm_eps: 1e-6
+      n_layer: 28
+      rope:
+          __type__: configs.RoPE_Config
+          base: 1000000.0


### PR DESCRIPTION
## Summary
- add a config file for `Qwen2.5-7B-Instruct` teacher weights

## Testing
- `python3 -m py_compile configs.py`
- `python3 -m py_compile train.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683b07d723d083238ced1a50a5e7eb0f