### PR TITLE
Fix invalid attention kernel setting

### DIFF
--- a/configs/qwerky6.yaml
+++ b/configs/qwerky6.yaml
@@ -1,6 +1,7 @@
 model:
   tmix: qwerky6
-  attention_type: rwkv6_wind_backstepping_longhead #gla
+  # The longhead kernels are not provided. Use the bighead variant instead.
+  attention_type: rwkv6_wind_backstepping_bighead
   reinit_att: 0
   gate_rank_type: 1
   use_pos_emb: 0

--- a/configs/qwerky7.yaml
+++ b/configs/qwerky7.yaml
@@ -1,6 +1,8 @@
 model:
   tmix: qwerky7
-  attention_type: rwkv7_wind_backstepping_longhead # rwkv7 # rwkv7_wind_backstepping_longhead # rwkv7_wind_replaystepping_longhead # 
+  # The longhead CUDA kernel is not included in the open-source release.
+  # Use the bighead kernel which is provided instead.
+  attention_type: rwkv7_wind_backstepping_bighead
   reinit_att: 0
   gate_rank_type: 2
   use_pos_emb: 1


### PR DESCRIPTION
## Summary
- switch configs to available `rwkv*_wind_backstepping_bighead` kernels

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683cb74c9e748323b36d3ef6965fab15